### PR TITLE
Fix scalar std deviations

### DIFF
--- a/chemprop/data/scaler.py
+++ b/chemprop/data/scaler.py
@@ -19,7 +19,7 @@ class StandardScaler:
         X = np.array(X).astype(float)
         self.means = np.nanmean(X, axis=0)
         self.stds = np.nanstd(X, axis=0)
-        self.stds = np.where(self.stds == 0, self.stds, np.ones(self.stds.shape))
+        self.stds = np.where(self.stds != 0, self.stds, np.ones(self.stds.shape))
 
         return self
 


### PR DESCRIPTION
numpy.where logic was inverted, the scalar was returning 1.0 for any non zero std deviation and 0.0 if the std deviation was already zero.